### PR TITLE
Fix starter data sync with new species

### DIFF
--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -629,6 +629,18 @@ export class GameData {
           }
         } else {
           this.starterData = systemData.starterData;
+          const starterSpeciesIds = Object.keys(speciesStarterCosts).map(
+            (k) => Number.parseInt(k) as Species,
+          );
+          for (const speciesId of starterSpeciesIds) {
+            if (!this.starterData[speciesId]) {
+              this.starterData[speciesId] = this.buildStarterDataEntry(speciesId);
+              if (!this.dexData[speciesId]) {
+                this.dexData[speciesId] =
+                  this.defaultDexData?.[speciesId] || this.buildDexEntry();
+              }
+            }
+          }
         }
 
         if (systemData.gameStats) {
@@ -1928,21 +1940,37 @@ export class GameData {
     );
 
     for (const speciesId of starterSpeciesIds) {
-      starterData[speciesId] = {
-        moveset: null,
-        eggMoves: 0,
-        candyCount: 0,
-        friendship: 0,
-        abilityAttr: defaultStarterSpecies.includes(speciesId)
-          ? AbilityAttr.ABILITY_1
-          : 0,
-        passiveAttr: 0,
-        valueReduction: 0,
-        classicWinCount: 0,
-      };
+      starterData[speciesId] = this.buildStarterDataEntry(speciesId);
     }
 
     this.starterData = starterData;
+  }
+
+  private buildStarterDataEntry(speciesId: Species): StarterDataEntry {
+    return {
+      moveset: null,
+      eggMoves: 0,
+      candyCount: 0,
+      friendship: 0,
+      abilityAttr: defaultStarterSpecies.includes(speciesId)
+        ? AbilityAttr.ABILITY_1
+        : 0,
+      passiveAttr: 0,
+      valueReduction: 0,
+    classicWinCount: 0,
+    };
+  }
+
+  private buildDexEntry(): DexEntry {
+    return {
+      seenAttr: 0n,
+      caughtAttr: 0n,
+      natureAttr: 0,
+      seenCount: 0,
+      caughtCount: 0,
+      hatchedCount: 0,
+      ivs: [0, 0, 0, 0, 0, 0],
+    };
   }
 
   setPokemonSeen(

--- a/test/system/starter_data_sync.test.ts
+++ b/test/system/starter_data_sync.test.ts
@@ -1,0 +1,32 @@
+import GameManager from "#test/testUtils/gameManager";
+import { Species } from "#enums/species";
+import Phaser from "phaser";
+import { beforeAll, beforeEach, afterEach, describe, it, expect } from "vitest";
+
+describe("System - Starter Data Sync", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({ type: Phaser.HEADLESS });
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  it("adds missing starter data entries when loading", async () => {
+    const save = game.scene.gameData.getSystemSaveData();
+    delete save.starterData[Species.ARTORIAS];
+    delete save.dexData[Species.ARTORIAS];
+
+    await game.scene.gameData.initSystem(JSON.stringify(save));
+
+    expect(game.scene.gameData.starterData[Species.ARTORIAS]).toBeDefined();
+    expect(game.scene.gameData.dexData[Species.ARTORIAS]).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add helper to build default starter data entries
- ensure starter data includes entries for any new species
- include default dex records when adding new species
- test starter data sync for Artorias

## Testing
- `npm run test` *(fails: vitest not found)*
- `npm run biome` *(fails: biome not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c625e27148326aa1d4ac521ecba14